### PR TITLE
feat(settings): streamline llm api config dialog

### DIFF
--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -804,5 +804,52 @@
   "about_more_info": "More info",
   "@about_more_info": {
     "description": "More info section title"
+  },
+  "llm_api_connection_info": "Connection",
+  "@llm_api_connection_info": {
+    "description": "LLM API dialog connection section title"
+  },
+  "llm_api_model_info": "Model",
+  "@llm_api_model_info": {
+    "description": "LLM API dialog model section title"
+  },
+  "llm_api_name": "Name",
+  "@llm_api_name": {
+    "description": "LLM API dialog name field label"
+  },
+  "llm_api_endpoint": "Endpoint URL",
+  "@llm_api_endpoint": {
+    "description": "LLM API dialog endpoint field label"
+  },
+  "llm_api_reset_form": "Reset form",
+  "@llm_api_reset_form": {
+    "description": "LLM API dialog reset whole form button"
+  },
+  "llm_api_models_empty": "No models found, you can still enter one manually",
+  "@llm_api_models_empty": {
+    "description": "LLM API dialog no models found message"
+  },
+  "llm_api_models_found": "Found {count} models",
+  "@llm_api_models_found": {
+    "description": "LLM API dialog models found message",
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "llm_api_fetch_failed_but_manual_ok": "Fetch failed, but manual entry is still available",
+  "@llm_api_fetch_failed_but_manual_ok": {
+    "description": "LLM API dialog fetch failed but manual input still okay"
+  },
+  "llm_api_fetch_prerequisite": "Enter endpoint URL and API key first",
+  "@llm_api_fetch_prerequisite": {
+    "description": "LLM API dialog fetch models prerequisites hint"
+  },
+  "llm_api_test_connection": "Test connection",
+  "@llm_api_test_connection": {
+    "description": "LLM API dialog test connection button"
+  },
+  "llm_api_connection_success": "Connection successful, ready to use",
+  "@llm_api_connection_success": {
+    "description": "LLM API dialog connection success message"
   }
 }

--- a/client/lib/l10n/app_zh.arb
+++ b/client/lib/l10n/app_zh.arb
@@ -363,5 +363,52 @@
     "about_more_info": "更多信息",
     "@about_more_info": {
       "description": "更多信息区块标题"
+    },
+    "llm_api_connection_info": "连接信息",
+    "@llm_api_connection_info": {
+      "description": "LLM API 弹窗连接信息区块标题"
+    },
+    "llm_api_model_info": "模型信息",
+    "@llm_api_model_info": {
+      "description": "LLM API 弹窗模型信息区块标题"
+    },
+    "llm_api_name": "Name",
+    "@llm_api_name": {
+      "description": "LLM API 弹窗名称字段标签"
+    },
+    "llm_api_endpoint": "Endpoint URL",
+    "@llm_api_endpoint": {
+      "description": "LLM API 弹窗 endpoint 字段标签"
+    },
+    "llm_api_reset_form": "重置表单",
+    "@llm_api_reset_form": {
+      "description": "LLM API 弹窗重置整个表单按钮"
+    },
+    "llm_api_models_empty": "未发现模型，你仍可手动输入",
+    "@llm_api_models_empty": {
+      "description": "LLM API 弹窗未发现模型提示"
+    },
+    "llm_api_models_found": "已发现 {count} 个模型",
+    "@llm_api_models_found": {
+      "description": "LLM API 弹窗发现模型提示",
+      "placeholders": {
+        "count": { "type": "int" }
+      }
+    },
+    "llm_api_fetch_failed_but_manual_ok": "获取失败，但仍可手动输入模型名",
+    "@llm_api_fetch_failed_but_manual_ok": {
+      "description": "LLM API 弹窗获取失败但仍可手输提示"
+    },
+    "llm_api_fetch_prerequisite": "先填写 Endpoint URL 和 API Key",
+    "@llm_api_fetch_prerequisite": {
+      "description": "LLM API 弹窗获取模型前置条件提示"
+    },
+    "llm_api_test_connection": "测试连接",
+    "@llm_api_test_connection": {
+      "description": "LLM API 弹窗测试连接按钮"
+    },
+    "llm_api_connection_success": "连接成功，可以开始使用",
+    "@llm_api_connection_success": {
+      "description": "LLM API 弹窗连接成功提示"
     }
 }

--- a/client/lib/models/ai.dart
+++ b/client/lib/models/ai.dart
@@ -13,11 +13,11 @@ abstract class LLMAgentRepo {
   LLMAgentsModel getLLMAgents();
   LLMAgentModel? getLastUsedLLMAgent();
   void updateLastUsedLLMAgent(LLMAgentId id);
-  void create(LLMAgentSettingModel setting);
+  LLMAgentId create(LLMAgentSettingModel setting, {LLMAgentStatusModel? status});
   void delete(LLMAgentId id);
   LLMAgentModel? getLLMAgentById(LLMAgentId id);
   void updateStatus(LLMAgentId id, LLMAgentStatusModel status);
-  void updateSetting(LLMAgentId id, LLMAgentSettingModel setting);
+  void updateSetting(LLMAgentId id, LLMAgentSettingModel setting, {LLMAgentStatusModel? status});
 }
 
 abstract class AIChatRepo {

--- a/client/lib/repositories/ai/agent.dart
+++ b/client/lib/repositories/ai/agent.dart
@@ -94,7 +94,7 @@ class LLMAgentRepoImpl implements LLMAgentRepo {
   }
 
   @override
-  void create(LLMAgentSettingModel setting) {
+  LLMAgentId create(LLMAgentSettingModel setting, {LLMAgentStatusModel? status}) {
     final model = _llmAgentSettingBox.put(
       LLMApiSettingStorage(
         name: setting.name,
@@ -104,7 +104,9 @@ class LLMAgentRepoImpl implements LLMAgentRepo {
       ),
     );
 
-    _status[LLMAgentId(value: model)] = const LLMAgentStatusModel(state: LLMAgentState.unknown);
+    final id = LLMAgentId(value: model);
+    _status[id] = status ?? const LLMAgentStatusModel(state: LLMAgentState.unknown);
+    return id;
   }
 
   @override
@@ -128,7 +130,7 @@ class LLMAgentRepoImpl implements LLMAgentRepo {
   }
 
   @override
-  void updateSetting(LLMAgentId id, LLMAgentSettingModel setting) {
+  void updateSetting(LLMAgentId id, LLMAgentSettingModel setting, {LLMAgentStatusModel? status}) {
     _llmAgentSettingBox.put(
       LLMApiSettingStorage(
         id: id.value,
@@ -139,8 +141,7 @@ class LLMAgentRepoImpl implements LLMAgentRepo {
       ),
     );
 
-    // 更新setting后，状态重置为unknown
-    _status[id] = const LLMAgentStatusModel(state: LLMAgentState.unknown);
+    _status[id] = status ?? const LLMAgentStatusModel(state: LLMAgentState.unknown);
   }
 }
 

--- a/client/lib/screens/settings/settings.dart
+++ b/client/lib/screens/settings/settings.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:client/models/ai.dart';
 import 'package:client/models/settings.dart';
 import 'package:client/screens/page_skeleton.dart';
 import 'package:client/services/ai/agent.dart';
+import 'package:client/services/ai/llm_sdk.dart';
 import 'package:client/services/settings/settings.dart';
 import 'package:client/widgets/button.dart';
 import 'package:client/widgets/const.dart';
@@ -208,22 +211,22 @@ class LLMApiSettingPage extends ConsumerWidget {
       maxCrossAxisExtent: 350,
       mainAxisSpacing: 10,
       crossAxisSpacing: 10,
-      childAspectRatio: 1.5,
+      childAspectRatio: 1.35,
       children: [
         for (var id in models.agents.keys)
           LLMApiSettingItem(
             key: Key(id.value.toString()),
             model: models.agents[id]!,
-            onUpdate: (m) {
-              ref.read(lLMAgentServiceProvider.notifier).updateSetting(id, m);
+            onUpdate: (m, status) {
+              ref.read(lLMAgentServiceProvider.notifier).updateSetting(id, m, status: status);
             },
             onDelete: (m) {
               ref.read(lLMAgentServiceProvider.notifier).delete(m);
             },
           ),
         AddLLMApiSettingItem(
-          onAdd: (m) {
-            ref.read(lLMAgentServiceProvider.notifier).create(m);
+          onAdd: (m, status) {
+            ref.read(lLMAgentServiceProvider.notifier).create(m, status: status);
           },
         ),
       ],
@@ -232,7 +235,12 @@ class LLMApiSettingPage extends ConsumerWidget {
 }
 
 // todo: 表单输入框抽取公共库
-InputDecoration _buildDialogInputDecoration(BuildContext context, {required String labelText}) {
+InputDecoration _buildDialogInputDecoration(
+  BuildContext context, {
+  required String labelText,
+  String? helperText,
+  Widget? suffixIcon,
+}) {
   final defaultBorder = OutlineInputBorder(
     borderSide: BorderSide(
       color: Theme.of(context).colorScheme.outline,
@@ -246,6 +254,8 @@ InputDecoration _buildDialogInputDecoration(BuildContext context, {required Stri
 
   return InputDecoration(
     labelText: labelText,
+    helperText: helperText,
+    suffixIcon: suffixIcon,
     border: defaultBorder,
     enabledBorder: defaultBorder,
     disabledBorder: defaultBorder,
@@ -255,96 +265,543 @@ InputDecoration _buildDialogInputDecoration(BuildContext context, {required Stri
   );
 }
 
+String _readableError(Object error) {
+  final text = error.toString().trim();
+  for (final prefix in const ['Exception: ', 'FormatException: ']) {
+    if (text.startsWith(prefix)) {
+      return text.substring(prefix.length);
+    }
+  }
+  return text;
+}
+
 void showLLMApiSettingDialog(
   BuildContext context,
   String title,
   LLMAgentModel? model,
-  Function(LLMAgentSettingModel) onSubmit,
+  void Function(LLMAgentSettingModel, LLMAgentStatusModel?) onSubmit,
 ) {
-  final nameController = TextEditingController(text: model?.setting.name);
-  final baseUrlController = TextEditingController(text: model?.setting.baseUrl);
-  final apiKeyController = TextEditingController(text: model?.setting.apiKey);
-  final modelNameController = TextEditingController(text: model?.setting.modelName);
-
   showDialog(
     context: context,
     builder: (context) {
-      return CustomDialog(
+      return _LLMApiSettingDialogContent(
         title: title,
-        subtitle: AppLocalizations.of(context)!.llm_api_only_openai_compatible,
-        titleIcon: Icon(Icons.extension, color: Theme.of(context).colorScheme.primary),
-        maxWidth: 600,
-        maxHeight: 420,
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-            child: Text(
-              AppLocalizations.of(context)!.cancel,
-            ),
-          ),
-          const SizedBox(width: kSpacingSmall),
-          TextButton(
-            onPressed: () {
-              onSubmit(
-                LLMAgentSettingModel(
-                  name: nameController.text,
-                  baseUrl: baseUrlController.text,
-                  apiKey: apiKeyController.text,
-                  modelName: modelNameController.text,
-                ),
-              );
-              Navigator.of(context).pop();
-            },
-            child: Text(AppLocalizations.of(context)!.submit),
-          ),
-        ],
-        content: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: nameController,
-              decoration: _buildDialogInputDecoration(
-                context,
-                labelText: 'Description',
-              ),
-            ),
-            const SizedBox(height: kSpacingMedium),
-            TextField(
-              controller: baseUrlController,
-              decoration: _buildDialogInputDecoration(
-                context,
-                labelText: 'Base URL',
-              ),
-            ),
-            const SizedBox(height: kSpacingMedium),
-            TextField(
-              controller: apiKeyController,
-              decoration: _buildDialogInputDecoration(
-                context,
-                labelText: 'API Key',
-              ),
-            ),
-            const SizedBox(height: kSpacingMedium),
-            TextField(
-              controller: modelNameController,
-              decoration: _buildDialogInputDecoration(
-                context,
-                labelText: 'Model',
-              ),
-            ),
-          ],
-        ),
+        model: model,
+        onSubmit: onSubmit,
       );
     },
   );
 }
 
+class _LLMApiSettingDialogContent extends ConsumerStatefulWidget {
+  final String title;
+  final LLMAgentModel? model;
+  final void Function(LLMAgentSettingModel, LLMAgentStatusModel?) onSubmit;
+
+  const _LLMApiSettingDialogContent({
+    required this.title,
+    required this.model,
+    required this.onSubmit,
+  });
+
+  @override
+  ConsumerState<_LLMApiSettingDialogContent> createState() => _LLMApiSettingDialogContentState();
+}
+
+class _LLMApiSettingDialogContentState extends ConsumerState<_LLMApiSettingDialogContent> {
+  final _formKey = GlobalKey<FormState>();
+
+  late final TextEditingController _nameController;
+  late final TextEditingController _baseUrlController;
+  late final TextEditingController _apiKeyController;
+  late final TextEditingController _modelController;
+  late final FocusNode _modelFocusNode;
+  late final MenuController _modelMenuController;
+
+  bool _obscureApiKey = true;
+  bool _isFetchingModels = false;
+  bool _isTestingConnection = false;
+  List<String> _availableModels = const [];
+  String? _fetchStatusMessage;
+  bool _fetchStatusError = false;
+  String? _testStatusMessage;
+  bool _testStatusError = false;
+  LLMAgentStatusModel? _draftStatusToSync;
+
+  @override
+  void initState() {
+    super.initState();
+    final setting = widget.model?.setting;
+    _nameController = TextEditingController(text: setting?.name ?? '');
+    _baseUrlController = TextEditingController(text: setting?.baseUrl ?? defaultOpenAIBaseUrl);
+    _apiKeyController = TextEditingController(text: setting?.apiKey ?? '');
+    _modelController = TextEditingController(text: setting?.modelName ?? '');
+    _modelFocusNode = FocusNode();
+    _modelMenuController = MenuController();
+    _modelFocusNode.addListener(_handleModelFieldFocusChange);
+    _modelController.addListener(_invalidateTestState);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _baseUrlController.dispose();
+    _apiKeyController.dispose();
+    _modelController.removeListener(_invalidateTestState);
+    _modelController.dispose();
+    _modelFocusNode.removeListener(_handleModelFieldFocusChange);
+    _modelFocusNode.dispose();
+    super.dispose();
+  }
+
+  LLMAgentSettingModel _buildDraftSetting() {
+    final rawName = _nameController.text.trim();
+    final modelName = _modelController.text.trim();
+
+    return LLMAgentSettingModel(
+      name: rawName.isNotEmpty
+          ? rawName
+          : buildDefaultLLMAgentName(
+              baseUrl: _baseUrlController.text.trim(),
+              modelName: modelName,
+            ),
+      baseUrl: _baseUrlController.text.trim(),
+      apiKey: _apiKeyController.text.trim(),
+      modelName: modelName,
+    );
+  }
+
+  bool _hasConnectionFieldsChanged() {
+    final original = widget.model?.setting;
+    if (original == null) {
+      return true;
+    }
+
+    return original.baseUrl.trim() != _baseUrlController.text.trim() ||
+        original.apiKey.trim() != _apiKeyController.text.trim() ||
+        original.modelName.trim() != _modelController.text.trim();
+  }
+
+  void _invalidateFetchState() {
+    final shouldUpdate = _fetchStatusMessage != null || _fetchStatusError || _availableModels.isNotEmpty;
+    if (!shouldUpdate) {
+      return;
+    }
+
+    setState(() {
+      _availableModels = const [];
+      _fetchStatusMessage = null;
+      _fetchStatusError = false;
+    });
+  }
+
+  void _invalidateTestState() {
+    final shouldUpdate = _testStatusMessage != null || _testStatusError || _draftStatusToSync != null;
+    if (!shouldUpdate) {
+      return;
+    }
+
+    setState(() {
+      _testStatusMessage = null;
+      _testStatusError = false;
+      _draftStatusToSync = null;
+    });
+  }
+
+  String? _requiredValidator(BuildContext context, String? value) {
+    if ((value ?? '').trim().isEmpty) {
+      return AppLocalizations.of(context)!.field_val_msg_value_reqiured;
+    }
+    return null;
+  }
+
+  bool _ensureModelSelected() {
+    if (_modelController.text.trim().isNotEmpty) {
+      return true;
+    }
+
+    setState(() {
+      _testStatusError = true;
+      _testStatusMessage = AppLocalizations.of(context)!.field_val_msg_value_reqiured;
+    });
+    _modelFocusNode.requestFocus();
+    return false;
+  }
+
+  void _handleModelFieldFocusChange() {
+    if (!_modelFocusNode.hasFocus || _isFetchingModels) {
+      return;
+    }
+
+    if (_baseUrlController.text.trim().isEmpty || _apiKeyController.text.trim().isEmpty) {
+      setState(() {
+        _fetchStatusError = true;
+        _fetchStatusMessage = AppLocalizations.of(context)!.llm_api_fetch_prerequisite;
+      });
+      return;
+    }
+
+    if (_availableModels.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _modelFocusNode.hasFocus) {
+          _modelMenuController.open();
+        }
+      });
+      return;
+    }
+
+    _handleFetchModels(openMenuAfterFetch: true);
+  }
+
+  Future<void> _handleFetchModels({bool openMenuAfterFetch = false}) async {
+    if (_baseUrlController.text.trim().isEmpty || _apiKeyController.text.trim().isEmpty) {
+      setState(() {
+        _fetchStatusError = true;
+        _fetchStatusMessage = AppLocalizations.of(context)!.llm_api_fetch_prerequisite;
+      });
+      return;
+    }
+
+    setState(() {
+      _isFetchingModels = true;
+      _fetchStatusError = false;
+      _fetchStatusMessage = null;
+    });
+
+    try {
+      final models = await ref.read(lLMAgentServiceProvider.notifier).fetchModelsDraft(_buildDraftSetting());
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _availableModels = models;
+        _fetchStatusError = false;
+        _fetchStatusMessage = models.isEmpty
+            ? AppLocalizations.of(context)!.llm_api_models_empty
+            : AppLocalizations.of(context)!.llm_api_models_found(models.length);
+      });
+      if (openMenuAfterFetch && models.isNotEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && _modelFocusNode.hasFocus) {
+            _modelMenuController.open();
+          }
+        });
+      }
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _availableModels = const [];
+        _fetchStatusError = true;
+        _fetchStatusMessage =
+            '${AppLocalizations.of(context)!.llm_api_fetch_failed_but_manual_ok}: ${_readableError(error)}';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isFetchingModels = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleTestConnection() async {
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+    if (!_ensureModelSelected()) {
+      return;
+    }
+
+    setState(() {
+      _isTestingConnection = true;
+      _testStatusError = false;
+      _testStatusMessage = null;
+    });
+
+    try {
+      await ref.read(lLMAgentServiceProvider.notifier).pingDraft(_buildDraftSetting());
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _testStatusError = false;
+        _testStatusMessage = AppLocalizations.of(context)!.llm_api_connection_success;
+        _draftStatusToSync = const LLMAgentStatusModel(state: LLMAgentState.available);
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      final message = _readableError(error);
+      setState(() {
+        _testStatusError = true;
+        _testStatusMessage = '${AppLocalizations.of(context)!.test_failed}: $message';
+        _draftStatusToSync = LLMAgentStatusModel(
+          state: LLMAgentState.unavailable,
+          error: message,
+        );
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isTestingConnection = false;
+        });
+      }
+    }
+  }
+
+  void _resetForm() {
+    final original = widget.model?.setting;
+    _formKey.currentState?.reset();
+    _nameController.text = original?.name ?? '';
+    _baseUrlController.text = original?.baseUrl ?? defaultOpenAIBaseUrl;
+    _apiKeyController.text = original?.apiKey ?? '';
+    _modelController.text = original?.modelName ?? '';
+    _availableModels = const [];
+    _fetchStatusMessage = null;
+    _fetchStatusError = false;
+    _testStatusMessage = null;
+    _testStatusError = false;
+    _draftStatusToSync = null;
+    setState(() {});
+  }
+
+  void _handleSubmit() {
+    if (_formKey.currentState?.validate() != true) {
+      return;
+    }
+    if (!_ensureModelSelected()) {
+      return;
+    }
+
+    final syncedStatus = _draftStatusToSync ?? (!_hasConnectionFieldsChanged() ? widget.model?.status : null);
+    widget.onSubmit(_buildDraftSetting(), syncedStatus);
+    Navigator.of(context).pop();
+  }
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleSmall,
+    );
+  }
+
+  Widget _buildSectionCard(BuildContext context, {required String title, required Widget child}) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colorScheme.outlineVariant),
+        color: colorScheme.surfaceContainerLow,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSectionTitle(context, title),
+          const SizedBox(height: 10),
+          child,
+        ],
+      ),
+    );
+  }
+
+  LLMAgentStatusModel get _effectiveDialogStatus {
+    if (_isTestingConnection) {
+      return const LLMAgentStatusModel(state: LLMAgentState.testing);
+    }
+    if (_draftStatusToSync != null) {
+      return _draftStatusToSync!;
+    }
+    if (!_hasConnectionFieldsChanged() && widget.model != null) {
+      return widget.model!.status;
+    }
+    return const LLMAgentStatusModel(state: LLMAgentState.unknown);
+  }
+
+  String _dialogStatusTooltip(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final status = _effectiveDialogStatus;
+    return switch (status.state) {
+      LLMAgentState.available => l10n.llm_api_connection_success,
+      LLMAgentState.unavailable => status.error ?? l10n.test_failed,
+      LLMAgentState.testing => l10n.testing,
+      LLMAgentState.unknown => l10n.llm_api_test_connection,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return CustomDialog(
+      title: widget.title,
+      subtitle: l10n.llm_api_only_openai_compatible,
+      titleIcon: Icon(Icons.extension, color: Theme.of(context).colorScheme.primary),
+      maxWidth: 720,
+      maxHeight: 560,
+      actions: [
+        TextButton(
+          onPressed: _resetForm,
+          child: Text(l10n.llm_api_reset_form),
+        ),
+        const SizedBox(width: kSpacingSmall),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: Text(l10n.cancel),
+        ),
+        const SizedBox(width: kSpacingSmall),
+        _LLMAgentTestAction(
+          status: _effectiveDialogStatus,
+          tooltip: _dialogStatusTooltip(context),
+          onPressed: _handleTestConnection,
+        ),
+        const SizedBox(width: kSpacingSmall),
+        FilledButton(
+          onPressed: _handleSubmit,
+          child: Text(l10n.submit),
+        ),
+      ],
+      content: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildSectionCard(
+                context,
+                title: l10n.llm_api_connection_info,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextFormField(
+                      key: const Key('llm-name-field'),
+                      controller: _nameController,
+                      decoration: _buildDialogInputDecoration(
+                        context,
+                        labelText: l10n.llm_api_name,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      key: const Key('llm-base-url-field'),
+                      controller: _baseUrlController,
+                      validator: (value) => _requiredValidator(context, value),
+                      onChanged: (_) {
+                        _invalidateFetchState();
+                        _invalidateTestState();
+                      },
+                      decoration: _buildDialogInputDecoration(
+                        context,
+                        labelText: l10n.llm_api_endpoint,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      key: const Key('llm-api-key-field'),
+                      controller: _apiKeyController,
+                      validator: (value) => _requiredValidator(context, value),
+                      obscureText: _obscureApiKey,
+                      onChanged: (_) {
+                        _invalidateFetchState();
+                        _invalidateTestState();
+                      },
+                      decoration: _buildDialogInputDecoration(
+                        context,
+                        labelText: 'API Key',
+                        suffixIcon: IconButton(
+                          icon: Icon(_obscureApiKey ? Icons.visibility_off : Icons.visibility),
+                          onPressed: () {
+                            setState(() {
+                              _obscureApiKey = !_obscureApiKey;
+                            });
+                          },
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _buildSectionCard(
+                context,
+                title: l10n.llm_api_model_info,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(
+                      key: const Key('llm-model-field'),
+                      width: double.infinity,
+                      child: LayoutBuilder(
+                        builder: (context, constraints) {
+                          return DropdownMenu<String>(
+                            controller: _modelController,
+                            focusNode: _modelFocusNode,
+                            menuController: _modelMenuController,
+                            width: constraints.maxWidth,
+                            menuHeight: 240,
+                            requestFocusOnTap: true,
+                            enableFilter: true,
+                            enableSearch: true,
+                            hintText: _isFetchingModels ? l10n.testing : null,
+                            helperText: null,
+                            label: const Text('Model'),
+                            onSelected: (selection) {
+                              if (selection == null) {
+                                return;
+                              }
+                              _modelController.text = selection;
+                              _invalidateTestState();
+                            },
+                            inputDecorationTheme: const InputDecorationTheme(
+                              border: OutlineInputBorder(),
+                            ),
+                            dropdownMenuEntries: _availableModels
+                                .map(
+                                  (option) => DropdownMenuEntry<String>(
+                                    value: option,
+                                    label: option,
+                                  ),
+                                )
+                                .toList(),
+                          );
+                        },
+                      ),
+                    ),
+                    if (_fetchStatusMessage != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        _isFetchingModels ? l10n.testing : _fetchStatusMessage!,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: _fetchStatusError ? colorScheme.error : colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class LLMApiSettingItem extends ConsumerWidget {
   final LLMAgentModel model;
-  final Function(LLMAgentSettingModel) onUpdate;
+  final void Function(LLMAgentSettingModel, LLMAgentStatusModel?) onUpdate;
   final Function(LLMAgentId) onDelete;
 
   const LLMApiSettingItem({
@@ -407,32 +864,15 @@ class LLMApiSettingItem extends ConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 const Spacer(),
-                switch (status.state) {
-                  LLMAgentState.testing => const Loading.small(),
-                  LLMAgentState.available => RectangleIconButton.small(
-                    tooltip: AppLocalizations.of(context)!.button_tooltip_ai_test,
-                    icon: Icons.check_circle_outline,
-                    iconColor: Colors.green,
-                    onPressed: () {
-                      ref.read(lLMAgentServiceProvider.notifier).ping(model.id);
-                    },
-                  ),
-                  LLMAgentState.unavailable => RectangleIconButton.small(
-                    tooltip: status.error ?? "",
-                    icon: Icons.error_outline,
-                    iconColor: Colors.red,
-                    onPressed: () {
-                      ref.read(lLMAgentServiceProvider.notifier).ping(model.id);
-                    },
-                  ),
-                  LLMAgentState.unknown => RectangleIconButton.small(
-                    tooltip: AppLocalizations.of(context)!.button_tooltip_ai_test,
-                    icon: Icons.flash_on,
-                    onPressed: () {
-                      ref.read(lLMAgentServiceProvider.notifier).ping(model.id);
-                    },
-                  ),
-                },
+                _LLMAgentTestAction(
+                  status: status,
+                  tooltip: status.state == LLMAgentState.unavailable
+                      ? (status.error ?? AppLocalizations.of(context)!.button_tooltip_ai_test)
+                      : AppLocalizations.of(context)!.button_tooltip_ai_test,
+                  onPressed: () async {
+                    ref.read(lLMAgentServiceProvider.notifier).ping(model.id);
+                  },
+                ),
                 RectangleIconButton.small(
                   icon: Icons.edit,
                   onPressed: () {
@@ -454,7 +894,7 @@ class LLMApiSettingItem extends ConsumerWidget {
 }
 
 class AddLLMApiSettingItem extends StatelessWidget {
-  final Function(LLMAgentSettingModel) onAdd;
+  final void Function(LLMAgentSettingModel, LLMAgentStatusModel?) onAdd;
   const AddLLMApiSettingItem({super.key, required this.onAdd});
 
   @override
@@ -509,5 +949,51 @@ class _InfoRow extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+class _LLMAgentTestAction extends StatelessWidget {
+  final LLMAgentStatusModel status;
+  final String tooltip;
+  final Future<void> Function() onPressed;
+
+  const _LLMAgentTestAction({
+    required this.status,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    switch (status.state) {
+      case LLMAgentState.testing:
+        return const Loading.small();
+      case LLMAgentState.available:
+        return RectangleIconButton.small(
+          tooltip: tooltip,
+          icon: Icons.check_circle_outline,
+          iconColor: Colors.green,
+          onPressed: () {
+            unawaited(onPressed());
+          },
+        );
+      case LLMAgentState.unavailable:
+        return RectangleIconButton.small(
+          tooltip: tooltip,
+          icon: Icons.error_outline,
+          iconColor: Theme.of(context).colorScheme.error,
+          onPressed: () {
+            unawaited(onPressed());
+          },
+        );
+      case LLMAgentState.unknown:
+        return RectangleIconButton.small(
+          tooltip: tooltip,
+          icon: Icons.flash_on,
+          onPressed: () {
+            unawaited(onPressed());
+          },
+        );
+    }
   }
 }

--- a/client/lib/services/ai/agent.dart
+++ b/client/lib/services/ai/agent.dart
@@ -18,9 +18,10 @@ class LLMAgentService extends _$LLMAgentService {
     return repo.getLLMAgents();
   }
 
-  void create(LLMAgentSettingModel setting) {
-    ref.read(lLMAgentRepoProvider).create(setting);
+  LLMAgentId create(LLMAgentSettingModel setting, {LLMAgentStatusModel? status}) {
+    final id = ref.read(lLMAgentRepoProvider).create(setting, status: status);
     ref.invalidateSelf();
+    return id;
   }
 
   void delete(LLMAgentId id) {
@@ -33,8 +34,8 @@ class LLMAgentService extends _$LLMAgentService {
     ref.invalidateSelf();
   }
 
-  void updateSetting(LLMAgentId id, LLMAgentSettingModel setting) {
-    ref.read(lLMAgentRepoProvider).updateSetting(id, setting);
+  void updateSetting(LLMAgentId id, LLMAgentSettingModel setting, {LLMAgentStatusModel? status}) {
+    ref.read(lLMAgentRepoProvider).updateSetting(id, setting, status: status);
     ref.invalidateSelf();
   }
 
@@ -53,11 +54,17 @@ class LLMAgentService extends _$LLMAgentService {
       repo.updateStatus(id, const LLMAgentStatusModel(state: LLMAgentState.testing));
       ref.invalidateSelf();
       final llmSdk = LLMProvider.create(model.setting, '');
-      final result = await llmSdk.call([
-        AIChatMessageItem.userMessage(
-          AIChatUserMessageModel(id: AIChatMessageId.generate(), content: testTemplate),
-        ),
-      ]);
+      final result = await (() async {
+        try {
+          return await llmSdk.call([
+            AIChatMessageItem.userMessage(
+              AIChatUserMessageModel(id: AIChatMessageId.generate(), content: testTemplate),
+            ),
+          ]);
+        } finally {
+          llmSdk.dispose();
+        }
+      })();
 
       final available = result.content.isNotEmpty;
       repo.updateStatus(
@@ -79,6 +86,31 @@ class LLMAgentService extends _$LLMAgentService {
     } finally {
       ref.invalidateSelf();
     }
+  }
+
+  Future<List<String>> fetchModelsDraft(LLMAgentSettingModel setting) async {
+    if (setting.baseUrl.trim().isEmpty) {
+      throw Exception('Base URL is required');
+    }
+    if (setting.apiKey.trim().isEmpty) {
+      throw Exception('API Key is required');
+    }
+
+    return fetchModelsForSetting(setting);
+  }
+
+  Future<void> pingDraft(LLMAgentSettingModel setting) async {
+    if (setting.baseUrl.trim().isEmpty) {
+      throw Exception('Base URL is required');
+    }
+    if (setting.apiKey.trim().isEmpty) {
+      throw Exception('API Key is required');
+    }
+    if (setting.modelName.trim().isEmpty) {
+      throw Exception('Model is required');
+    }
+
+    await pingDraftSetting(setting);
   }
 
   /// 从AI响应中提取JSON字符串（去掉markdown代码块标记）
@@ -128,11 +160,17 @@ class LLMAgentService extends _$LLMAgentService {
 
     final llmSdk = LLMProvider.create(model.setting, '');
     // 调用AI
-    final chatResult = await llmSdk.call([
-      AIChatMessageItem.userMessage(
-        AIChatUserMessageModel(id: AIChatMessageId.generate(), content: prompt),
-      ),
-    ]);
+    final chatResult = await (() async {
+      try {
+        return await llmSdk.call([
+          AIChatMessageItem.userMessage(
+            AIChatUserMessageModel(id: AIChatMessageId.generate(), content: prompt),
+          ),
+        ]);
+      } finally {
+        llmSdk.dispose();
+      }
+    })();
 
     // 检查响应是否为空
     if (chatResult.content.isEmpty) {

--- a/client/lib/services/ai/llm_sdk.dart
+++ b/client/lib/services/ai/llm_sdk.dart
@@ -1,9 +1,128 @@
 import 'dart:convert';
 
 import 'package:client/models/ai.dart';
+import 'package:http/http.dart' as http;
 import 'package:openai_dart/openai_dart.dart';
 
 import 'package:client/services/ai/tool.dart';
+
+const String defaultOpenAIBaseUrl = 'https://api.openai.com/v1';
+
+String normalizeLLMBaseUrl(String raw) {
+  var value = raw.trim();
+  if (value.isEmpty) {
+    return value;
+  }
+
+  while (value.endsWith('/')) {
+    value = value.substring(0, value.length - 1);
+  }
+
+  for (final suffix in const ['/chat/completions', '/models']) {
+    if (value.endsWith(suffix)) {
+      value = value.substring(0, value.length - suffix.length);
+    }
+  }
+
+  final uri = Uri.tryParse(value);
+  if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+    throw const FormatException('Invalid Base URL');
+  }
+
+  if (!value.endsWith('/v1')) {
+    value = '$value/v1';
+  }
+
+  return value;
+}
+
+bool isOfficialOpenAIBaseUrl(String raw) {
+  try {
+    return normalizeLLMBaseUrl(raw) == defaultOpenAIBaseUrl;
+  } on FormatException {
+    return false;
+  }
+}
+
+String buildDefaultLLMAgentName({
+  required String baseUrl,
+  required String modelName,
+}) {
+  final trimmedModelName = modelName.trim();
+  if (trimmedModelName.isEmpty) {
+    return '';
+  }
+
+  return isOfficialOpenAIBaseUrl(baseUrl) ? 'OpenAI / $trimmedModelName' : 'Custom / $trimmedModelName';
+}
+
+Future<List<String>> fetchModelsForSetting(LLMAgentSettingModel setting) async {
+  final normalizedBaseUrl = normalizeLLMBaseUrl(setting.baseUrl);
+  final client = OpenAIClient(
+    apiKey: setting.apiKey.trim(),
+    baseUrl: normalizedBaseUrl,
+  );
+
+  try {
+    try {
+      final response = await client.listModels();
+      return response.data.map((model) => model.id.trim()).where((id) => id.isNotEmpty).toSet().toList()..sort();
+    } catch (_) {
+      final response = await http.get(
+        Uri.parse('$normalizedBaseUrl/models'),
+        headers: {
+          'Authorization': 'Bearer ${setting.apiKey.trim()}',
+          'Content-Type': 'application/json',
+        },
+      );
+
+      if (response.statusCode == 401 || response.statusCode == 403) {
+        throw Exception('Authentication failed');
+      }
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw Exception('Failed to fetch models (${response.statusCode})');
+      }
+
+      final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+      final data = decoded['data'];
+      if (data is! List) {
+        return const [];
+      }
+
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map((item) => (item['id'] ?? '').toString().trim())
+          .where((id) => id.isNotEmpty)
+          .toSet()
+          .toList()
+        ..sort();
+    }
+  } finally {
+    client.endSession();
+  }
+}
+
+Future<void> pingDraftSetting(LLMAgentSettingModel setting) async {
+  final llmSdk = LLMProvider.create(
+    setting.copyWith(baseUrl: normalizeLLMBaseUrl(setting.baseUrl)),
+    '',
+  );
+
+  try {
+    final result = await llmSdk.call([
+      AIChatMessageItem.userMessage(
+        AIChatUserMessageModel(id: AIChatMessageId.generate(), content: 'Reply with OK only.'),
+      ),
+    ]);
+
+    if (result.content.trim().isEmpty) {
+      throw Exception('The selected model returned an empty response');
+    }
+  } finally {
+    llmSdk.dispose();
+  }
+}
 
 /// 跨 Provider 的 usage 统一结构
 class ChatUsage {
@@ -127,7 +246,7 @@ class OpenAIProvider implements LLMProvider {
     List<AITool>? tools,
   }) : _client = OpenAIClient(
          apiKey: setting.apiKey,
-         baseUrl: setting.baseUrl.isNotEmpty ? setting.baseUrl : null,
+         baseUrl: setting.baseUrl.isNotEmpty ? normalizeLLMBaseUrl(setting.baseUrl) : null,
        ),
        modelName = setting.modelName,
        tools = tools?.map((tool) => _convertToolToOpenAI(tool)).toList();
@@ -369,22 +488,23 @@ class OpenAIProvider implements LLMProvider {
 
   @override
   Future<ChatResult> call(List<AIChatMessageItem> messages) async {
-    try {
-      final request = CreateChatCompletionRequest(
-        model: ChatCompletionModel.modelId(modelName),
-        messages: _buildChatMessages(messages),
-        temperature: temperature,
-        tools: tools,
-      );
+    final request = CreateChatCompletionRequest(
+      model: ChatCompletionModel.modelId(modelName),
+      messages: _buildChatMessages(messages),
+      temperature: temperature,
+      tools: tools,
+    );
 
-      final response = await _client.createChatCompletion(request: request);
-      if (response.choices.isNotEmpty) {
-        return _messageToChatResult(response.choices.first.message);
-      }
-      return ChatResult(content: '');
-    } catch (e) {
+    final response = await _client.createChatCompletion(request: request);
+    if (response.choices.isNotEmpty) {
+      return _messageToChatResult(response.choices.first.message);
+    }
+
+    if (response.choices.isEmpty) {
       return ChatResult(content: '');
     }
+
+    return ChatResult(content: '');
   }
 
   @override

--- a/client/test/settings/llm_api_setting_dialog_test.dart
+++ b/client/test/settings/llm_api_setting_dialog_test.dart
@@ -1,0 +1,214 @@
+import 'package:client/l10n/app_localizations.dart';
+import 'package:client/models/ai.dart';
+import 'package:client/screens/settings/settings.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LLM API setting dialog', () {
+    testWidgets('create mode prefills official endpoint and shows new actions', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: _DialogTestApp(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-create-dialog')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Name'), findsOneWidget);
+      expect(find.text('Description'), findsNothing);
+      expect(find.text('https://api.openai.com/v1'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Fetch models'), findsNothing);
+      expect(find.byIcon(Icons.flash_on), findsOneWidget);
+    });
+
+    testWidgets('create mode auto fills name when left blank', (tester) async {
+      LLMAgentSettingModel? submitted;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: _DialogTestApp(
+            onSubmit: (setting, _) {
+              submitted = setting;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-create-dialog')));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('llm-api-key-field')), 'sk-test');
+      await tester.enterText(
+        find.descendant(
+          of: find.byKey(const Key('llm-model-field')),
+          matching: find.byType(EditableText),
+        ),
+        'gpt-4.1',
+      );
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+
+      expect(submitted, isNotNull);
+      expect(submitted!.name, 'OpenAI / gpt-4.1');
+      expect(submitted!.baseUrl, 'https://api.openai.com/v1');
+      expect(submitted!.apiKey, 'sk-test');
+      expect(submitted!.modelName, 'gpt-4.1');
+    });
+
+    testWidgets('edit mode keeps original values', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: _DialogTestApp(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-edit-dialog')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('https://api.deepseek.com/v1'), findsOneWidget);
+      expect(find.text('deepseek-chat'), findsOneWidget);
+      expect(find.text('DeepSeek Prod'), findsOneWidget);
+    });
+
+    testWidgets('edit mode preserves existing status when connection fields stay unchanged', (tester) async {
+      LLMAgentStatusModel? submittedStatus;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: _DialogTestApp(
+            onSubmit: (setting, status) {
+              submittedStatus = status;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-edit-dialog')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+
+      expect(submittedStatus, isNotNull);
+      expect(submittedStatus!.state, LLMAgentState.available);
+    });
+
+    testWidgets('edit mode clears synced status when connection fields change without retest', (tester) async {
+      LLMAgentStatusModel? submittedStatus;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: _DialogTestApp(
+            onSubmit: (setting, status) {
+              submittedStatus = status;
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-edit-dialog')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.descendant(
+          of: find.byKey(const Key('llm-model-field')),
+          matching: find.byType(EditableText),
+        ),
+        'gpt-5.5',
+      );
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+
+      expect(submittedStatus, isNull);
+    });
+
+    testWidgets('reset form restores saved values in edit mode', (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: _DialogTestApp(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('open-edit-dialog')));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('llm-name-field')), 'Changed name');
+      await tester.enterText(find.byKey(const Key('llm-base-url-field')), 'https://example.com/v1');
+      await tester.enterText(find.byKey(const Key('llm-api-key-field')), 'sk-changed');
+      await tester.enterText(
+        find.descendant(
+          of: find.byKey(const Key('llm-model-field')),
+          matching: find.byType(EditableText),
+        ),
+        'gpt-5.5',
+      );
+
+      await tester.tap(find.text('Reset form'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('DeepSeek Prod'), findsOneWidget);
+      expect(find.text('https://api.deepseek.com/v1'), findsOneWidget);
+      expect(find.text('deepseek-chat'), findsOneWidget);
+    });
+  });
+}
+
+class _DialogTestApp extends StatelessWidget {
+  final void Function(LLMAgentSettingModel setting, LLMAgentStatusModel? status)? onSubmit;
+
+  const _DialogTestApp({this.onSubmit});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            return Column(
+              children: [
+                TextButton(
+                  key: const Key('open-create-dialog'),
+                  onPressed: () {
+                    showLLMApiSettingDialog(
+                      context,
+                      'Create',
+                      null,
+                      onSubmit ?? _noopSubmit,
+                    );
+                  },
+                  child: const Text('Open create'),
+                ),
+                TextButton(
+                  key: const Key('open-edit-dialog'),
+                  onPressed: () {
+                    showLLMApiSettingDialog(
+                      context,
+                      'Update',
+                      LLMAgentModel(
+                        id: const LLMAgentId(value: 1),
+                        setting: const LLMAgentSettingModel(
+                          name: 'DeepSeek Prod',
+                          baseUrl: 'https://api.deepseek.com/v1',
+                          apiKey: 'sk-existing',
+                          modelName: 'deepseek-chat',
+                        ),
+                        status: const LLMAgentStatusModel(state: LLMAgentState.available),
+                      ),
+                      onSubmit ?? _noopSubmit,
+                    );
+                  },
+                  child: const Text('Open edit'),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+void _noopSubmit(LLMAgentSettingModel setting, LLMAgentStatusModel? status) {}


### PR DESCRIPTION
## Summary
**LLM API dialog**
- reworked the settings dialog into a tighter one-screen flow for desktop use
- changed the model field into a searchable dropdown that fetches model options on focus
- removed the bulky status panel and reused the compact test icon pattern for feedback

**Status sync**
- sync the saved card status with the latest in-dialog test result on submit
- preserve existing saved status when connection fields are unchanged
- invalidate stale test state when endpoint, API key, or model changes

**Stability and verification**
- added widget coverage for default values, auto naming, status sync, and reset behavior
- fixed reset behavior so edit mode restores saved values instead of clearing them

## Test Coverage
Added focused widget coverage for the dialog flow.

Tests added:
- create mode default endpoint and actions
- auto-fill name when blank
- edit mode value retention
- saved status preservation when fields unchanged
- stale status clearing when fields change without retest
- reset form restores saved values

## demo video

https://github.com/user-attachments/assets/e4c4bd75-b3cc-4bc1-8741-a0dfe08e7c48



## Pre-Landing Review
No issues found.

## Eval Results
No prompt-related files changed, evals skipped.

## Scope Drift
Scope Check: CLEAN
Intent: streamline the LLM API settings dialog and tighten status synchronization
Delivered: a compact searchable model picker flow with synced test status and regression tests

## Plan Completion
No plan file detected.

## Verification Results
No plan verification section detected, skipped.

## Test Plan
- [x] `cd client && fvm flutter analyze`
- [x] `cd client && fvm flutter test`