### PR TITLE
update star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Database drivers are implemented in [`pkg/db_driver/go_impl`](./pkg/db_driver/go
 4. Storage: [ObjectBox](https://objectbox.io/)
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=sjjian/openhare&type=date&legend=top-left)](https://www.star-history.com/#sjjian/openhare&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sjjian/openhare&type=date&legend=top-left)](https://star-history.dera.page/#sjjian/openhare&type=date&legend=top-left)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,4 +56,4 @@ openhare 是一款 AI 驱动的跨平台桌面 SQL 客户端，支持多数据�
 4. 存储： [ObjectBox](https://objectbox.io/)
 
 ## Star 历史
-[![Star History Chart](https://api.star-history.com/svg?repos=sjjian/openhare&type=date&legend=top-left)](https://www.star-history.com/#sjjian/openhare&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=sjjian/openhare&type=date&legend=top-left)](https://star-history.dera.page/#sjjian/openhare&type=date&legend=top-left)


### PR DESCRIPTION
修复 README 中 Star History 图表无法正常显示的问题。由于 GitHub 限制导致原图表失效，本 PR 将图表切换到新的数据源，使其恢复正常展示。